### PR TITLE
Use io.Reader interface as NewPlanData function parameter

### DIFF
--- a/cmd/terraform-j2md/main.go
+++ b/cmd/terraform-j2md/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io"
 	"os"
 
 	"github.com/reproio/terraform-j2md/internal/terraform"
@@ -13,12 +12,7 @@ func main() {
 }
 
 func run() int {
-	input, err := io.ReadAll(os.Stdin)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "cannot read stdin: %v", err)
-		return 1
-	}
-	planData, err := terraform.NewPlanData(input)
+	planData, err := terraform.NewPlanData(os.Stdin)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "cannot parse input as Terraform plan JSON: %v", err)
 		return 1

--- a/internal/terraform/plan.go
+++ b/internal/terraform/plan.go
@@ -105,9 +105,9 @@ func (plan *PlanData) Render(w io.Writer) error {
 	return nil
 }
 
-func NewPlanData(input []byte) (*PlanData, error) {
+func NewPlanData(input io.Reader) (*PlanData, error) {
 	var plan tfjson.Plan
-	if err := json.Unmarshal(input, &plan); err != nil {
+	if err := json.NewDecoder(input).Decode(&plan); err != nil {
 		return nil, fmt.Errorf("cannot parse input: %w", err)
 	}
 	sanitizedPlan, err := sanitize.SanitizePlan(&plan)

--- a/internal/terraform/plan_test.go
+++ b/internal/terraform/plan_test.go
@@ -35,6 +35,7 @@ func Test_newPlanData(t *testing.T) {
 				t.Errorf("cannot open input file: %s", inputFilePath)
 				return
 			}
+			defer file.Close()
 
 			_, err = NewPlanData(file)
 			if (err != nil) != tt.wantErr {
@@ -68,6 +69,7 @@ func Test_render(t *testing.T) {
 				t.Errorf("cannot open input file: %s", inputFilePath)
 				return
 			}
+			defer file.Close()
 
 			plan, err := NewPlanData(file)
 			if err != nil {

--- a/internal/terraform/plan_test.go
+++ b/internal/terraform/plan_test.go
@@ -30,13 +30,13 @@ func Test_newPlanData(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			inputFilePath := testDataPath(tt.name, "show.json")
-			input, err := os.ReadFile(inputFilePath)
+			file, err := os.Open(inputFilePath)
 			if err != nil {
 				t.Errorf("cannot open input file: %s", inputFilePath)
 				return
 			}
 
-			_, err = NewPlanData(input)
+			_, err = NewPlanData(file)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewPlanData() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -63,13 +63,13 @@ func Test_render(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			inputFilePath := testDataPath(tt.name, "show.json")
-			input, err := os.ReadFile(inputFilePath)
+			file, err := os.Open(inputFilePath)
 			if err != nil {
 				t.Errorf("cannot open input file: %s", inputFilePath)
 				return
 			}
 
-			plan, err := NewPlanData(input)
+			plan, err := NewPlanData(file)
 			if err != nil {
 				t.Errorf("cannot parse JSON as plan: %v", err)
 				return


### PR DESCRIPTION
`NewPlanData`に渡す`input`を`[]byte`じゃなくて`io.Reader`で受け取るようにしました。`io.Reader`で受け取った方がインプットとして柔軟に受け取れるだろうというのと、`json#Decoder.UseNumber`を将来的に使いたいので`io.Reader`で受け取るようにします。

https://pkg.go.dev/encoding/json#Decoder.UseNumber