### PR TITLE
support to display `known after apply` in-place update

### DIFF
--- a/internal/format/format_json.go
+++ b/internal/format/format_json.go
@@ -2,27 +2,10 @@ package format
 
 import (
 	"encoding/json"
-	"errors"
 	tfjson "github.com/hashicorp/terraform-json"
 )
 
-func FormatJsonPlan(plan *tfjson.Plan) (*tfjson.Plan, error) {
-	var err error
-	if plan == nil {
-		return nil, errors.New("nil plan supplied")
-	}
-
-	for i := range plan.ResourceChanges {
-		plan.ResourceChanges[i].Change, err = formatJsonChange(plan.ResourceChanges[i].Change)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return plan, nil
-}
-
-func formatJsonChange(change *tfjson.Change) (*tfjson.Change, error) {
+func FormatJsonChange(change *tfjson.Change) (*tfjson.Change, error) {
 	var err error
 
 	change.Before, err = formatJsonChangeValue(change.Before)

--- a/internal/format/format_unknown.go
+++ b/internal/format/format_unknown.go
@@ -1,0 +1,34 @@
+package format
+
+import (
+	"errors"
+	tfjson "github.com/hashicorp/terraform-json"
+)
+
+func FormatUnknownPlan(plan *tfjson.Plan) (*tfjson.Plan, error) {
+	var err error
+	if plan == nil {
+		return nil, errors.New("nil plan supplied")
+	}
+
+	for i := range plan.ResourceChanges {
+		plan.ResourceChanges[i].Change, err = formatUnknownChange(plan.ResourceChanges[i].Change)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return plan, nil
+}
+
+func formatUnknownChange(change *tfjson.Change) (*tfjson.Change, error) {
+	if change.Actions.Update() {
+		for k, v := range change.AfterUnknown.(map[string]interface{}) {
+			switch v.(type) {
+			case bool:
+				change.After.(map[string]interface{})[k] = "(known after apply)"
+			}
+		}
+	}
+	return change, nil
+}

--- a/internal/format/format_unknown.go
+++ b/internal/format/format_unknown.go
@@ -1,27 +1,10 @@
 package format
 
 import (
-	"errors"
 	tfjson "github.com/hashicorp/terraform-json"
 )
 
-func FormatUnknownPlan(plan *tfjson.Plan) (*tfjson.Plan, error) {
-	var err error
-	if plan == nil {
-		return nil, errors.New("nil plan supplied")
-	}
-
-	for i := range plan.ResourceChanges {
-		plan.ResourceChanges[i].Change, err = formatUnknownChange(plan.ResourceChanges[i].Change)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return plan, nil
-}
-
-func formatUnknownChange(change *tfjson.Change) (*tfjson.Change, error) {
+func FormatUnknownChange(change *tfjson.Change) (*tfjson.Change, error) {
 	if change.Actions.Update() {
 		for k, v := range change.AfterUnknown.(map[string]interface{}) {
 			switch v.(type) {

--- a/internal/terraform/plan.go
+++ b/internal/terraform/plan.go
@@ -149,17 +149,17 @@ func processPlan(plan *tfjson.Plan) (*tfjson.Plan, error) {
 	for i := range plan.ResourceChanges {
 		plan.ResourceChanges[i].Change, err = sanitize.SanitizeChange(plan.ResourceChanges[i].Change, sanitize.DefaultSensitiveValue)
 		if err != nil {
-			return nil, fmt.Errorf("failed to sanitize plan: %w", err)
+			return nil, fmt.Errorf("failed to sanitize change: %w", err)
 		}
 
 		plan.ResourceChanges[i].Change, err = format.FormatJsonChange(plan.ResourceChanges[i].Change)
 		if err != nil {
-			return nil, fmt.Errorf("failed to prettify plan: %w", err)
+			return nil, fmt.Errorf("failed to format json change: %w", err)
 		}
 
 		plan.ResourceChanges[i].Change, err = format.FormatUnknownChange(plan.ResourceChanges[i].Change)
 		if err != nil {
-			return nil, fmt.Errorf("failed to prettify plan: %w", err)
+			return nil, fmt.Errorf("failed to format unknown change: %w", err)
 		}
 	}
 

--- a/test/format_json_test/format_json_test.go
+++ b/test/format_json_test/format_json_test.go
@@ -9,80 +9,56 @@ import (
 
 func TestFormatJsonPlan(t *testing.T) {
 	type args struct {
-		old *tfjson.Plan
+		old *tfjson.Change
 	}
 	tests := []struct {
 		name    string
 		args    args
-		want    *tfjson.Plan
+		want    *tfjson.Change
 		wantErr bool
 	}{
 		{
 			name: "plain string",
 			args: args{
-				old: &tfjson.Plan{
-					ResourceChanges: []*tfjson.ResourceChange{
-						{
-							Change: &tfjson.Change{
-								Before: "plain string",
-								After:  "plain string",
-							},
-						},
-					},
+				old: &tfjson.Change{
+					Before: "plain string",
+					After:  "plain string",
 				},
 			},
-			want: &tfjson.Plan{
-				ResourceChanges: []*tfjson.ResourceChange{
-					{
-						Change: &tfjson.Change{
-							Before: "plain string",
-							After:  "plain string",
-						},
-					},
-				},
+			want: &tfjson.Change{
+				Before: "plain string",
+				After:  "plain string",
 			},
 			wantErr: false,
 		},
 		{
 			name: "json string",
 			args: args{
-				old: &tfjson.Plan{
-					ResourceChanges: []*tfjson.ResourceChange{
-						{
-							Change: &tfjson.Change{
-								Before: `{"foo":"bar"}`,
-								After:  `{"foo":"bar"}`,
-							},
-						},
-					},
+				old: &tfjson.Change{
+					Before: `{"foo":"bar"}`,
+					After:  `{"foo":"bar"}`,
 				},
 			},
-			want: &tfjson.Plan{
-				ResourceChanges: []*tfjson.ResourceChange{
-					{
-						Change: &tfjson.Change{
-							Before: `{
+			want: &tfjson.Change{
+				Before: `{
   "foo": "bar"
 }`,
-							After: `{
+				After: `{
   "foo": "bar"
 }`,
-						},
-					},
-				},
 			},
 			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := format.FormatJsonPlan(tt.args.old)
+			got, err := format.FormatJsonChange(tt.args.old)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("FormatJsonPlan() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("FormatJsonPlan() got = \n%v\n, want \n%v", got.ResourceChanges[0].Change.After, tt.want.ResourceChanges[0].Change.After)
+				t.Errorf("FormatJsonPlan() got = \n%v\n, want \n%v", got.After, tt.want.After)
 			}
 		})
 	}

--- a/test/format_json_test/format_unknown_test.go
+++ b/test/format_json_test/format_unknown_test.go
@@ -9,50 +9,38 @@ import (
 
 func TestFormatUnknownPlan(t *testing.T) {
 	type args struct {
-		old *tfjson.Plan
+		old *tfjson.Change
 	}
 	tests := []struct {
 		name    string
 		args    args
-		want    *tfjson.Plan
+		want    *tfjson.Change
 		wantErr bool
 	}{
 		{
 			name: "plain string",
 			args: args{
-				old: &tfjson.Plan{
-					ResourceChanges: []*tfjson.ResourceChange{
-						{
-							Change: &tfjson.Change{
-								Actions: tfjson.Actions{tfjson.ActionUpdate},
-								Before: map[string]interface{}{
-									"foo": "bar",
-								},
-								After: map[string]interface{}{},
-								AfterUnknown: map[string]interface{}{
-									"foo": true,
-								},
-							},
-						},
+				old: &tfjson.Change{
+					Actions: tfjson.Actions{tfjson.ActionUpdate},
+					Before: map[string]interface{}{
+						"foo": "bar",
+					},
+					After: map[string]interface{}{},
+					AfterUnknown: map[string]interface{}{
+						"foo": true,
 					},
 				},
 			},
-			want: &tfjson.Plan{
-				ResourceChanges: []*tfjson.ResourceChange{
-					{
-						Change: &tfjson.Change{
-							Actions: tfjson.Actions{tfjson.ActionUpdate},
-							Before: map[string]interface{}{
-								"foo": "bar",
-							},
-							After: map[string]interface{}{
-								"foo": "(known after apply)",
-							},
-							AfterUnknown: map[string]interface{}{
-								"foo": true,
-							},
-						},
-					},
+			want: &tfjson.Change{
+				Actions: tfjson.Actions{tfjson.ActionUpdate},
+				Before: map[string]interface{}{
+					"foo": "bar",
+				},
+				After: map[string]interface{}{
+					"foo": "(known after apply)",
+				},
+				AfterUnknown: map[string]interface{}{
+					"foo": true,
 				},
 			},
 			wantErr: false,
@@ -60,13 +48,13 @@ func TestFormatUnknownPlan(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := format.FormatUnknownPlan(tt.args.old)
+			got, err := format.FormatUnknownChange(tt.args.old)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("FormatJsonPlan() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("FormatJsonPlan() got = \n%v\n, want \n%v", got.ResourceChanges[0].Change.After, tt.want.ResourceChanges[0].Change.After)
+				t.Errorf("FormatJsonPlan() got = \n%v\n, want \n%v", got.After, tt.want.After)
 			}
 		})
 	}

--- a/test/format_json_test/format_unknown_test.go
+++ b/test/format_json_test/format_unknown_test.go
@@ -1,0 +1,73 @@
+package format_json_test
+
+import (
+	tfjson "github.com/hashicorp/terraform-json"
+	"github.com/reproio/terraform-j2md/internal/format"
+	"reflect"
+	"testing"
+)
+
+func TestFormatUnknownPlan(t *testing.T) {
+	type args struct {
+		old *tfjson.Plan
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *tfjson.Plan
+		wantErr bool
+	}{
+		{
+			name: "plain string",
+			args: args{
+				old: &tfjson.Plan{
+					ResourceChanges: []*tfjson.ResourceChange{
+						{
+							Change: &tfjson.Change{
+								Actions: tfjson.Actions{tfjson.ActionUpdate},
+								Before: map[string]interface{}{
+									"foo": "bar",
+								},
+								After: map[string]interface{}{},
+								AfterUnknown: map[string]interface{}{
+									"foo": true,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &tfjson.Plan{
+				ResourceChanges: []*tfjson.ResourceChange{
+					{
+						Change: &tfjson.Change{
+							Actions: tfjson.Actions{tfjson.ActionUpdate},
+							Before: map[string]interface{}{
+								"foo": "bar",
+							},
+							After: map[string]interface{}{
+								"foo": "(known after apply)",
+							},
+							AfterUnknown: map[string]interface{}{
+								"foo": true,
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := format.FormatUnknownPlan(tt.args.old)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("FormatJsonPlan() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FormatJsonPlan() got = \n%v\n, want \n%v", got.ResourceChanges[0].Change.After, tt.want.ResourceChanges[0].Change.After)
+			}
+		})
+	}
+}

--- a/test/plan_test/plan_test.go
+++ b/test/plan_test/plan_test.go
@@ -63,6 +63,7 @@ func Test_render(t *testing.T) {
 			{name: "iam_policy", wantErr: false},
 			{name: "include_code_fence", wantErr: false},
 			{name: "include_module", wantErr: false},
+			{name: "known_after_apply", wantErr: false},
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {

--- a/test/testdata/known_after_apply/expected.md
+++ b/test/testdata/known_after_apply/expected.md
@@ -1,0 +1,51 @@
+### 1 to add, 1 to change, 1 to destroy, 0 to replace.
+- add
+    - random_id.test2
+- change
+    - env_variable.test
+- destroy
+    - random_id.test
+<details><summary>Change details</summary>
+
+````````diff
+# env_variable.test will be updated in-place
+@@ -1,6 +1,6 @@
+ {
+   "id": "07ec30c9d869e0f6392f",
+-  "name": "07ec30c9d869e0f6392f",
++  "name": "(known after apply)",
+   "value": "REDACTED_SENSITIVE"
+ }
+ 
+````````
+
+````````diff
+# random_id.test will be destroyed
+@@ -1,11 +1,2 @@
+-{
+-  "b64_std": "B+wwydhp4PY5Lw==",
+-  "b64_url": "B-wwydhp4PY5Lw",
+-  "byte_length": 10,
+-  "dec": "37413512560416367458607",
+-  "hex": "07ec30c9d869e0f6392f",
+-  "id": "B-wwydhp4PY5Lw",
+-  "keepers": null,
+-  "prefix": null
+-}
++null
+ 
+````````
+
+````````diff
+# random_id.test2 will be created
+@@ -1,2 +1,6 @@
+-null
++{
++  "byte_length": 10,
++  "keepers": null,
++  "prefix": null
++}
+ 
+````````
+
+</details>

--- a/test/testdata/known_after_apply/main.tf
+++ b/test/testdata/known_after_apply/main.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    env = {
+      source = "tchupp/env"
+      version = "0.0.2"
+    }
+  }
+}
+
+provider "env" {
+  # Configuration options
+}
+
+resource "env_variable" "test" {
+  name = random_id.test2.hex
+}
+
+#resource "random_id" "test" {
+#  byte_length = 10
+#}
+
+resource "random_id" "test2" {
+  byte_length = 10
+}

--- a/test/testdata/known_after_apply/show.json
+++ b/test/testdata/known_after_apply/show.json
@@ -1,0 +1,227 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.5.3",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "env_variable.test",
+          "mode": "managed",
+          "type": "env_variable",
+          "name": "test",
+          "provider_name": "registry.terraform.io/tchupp/env",
+          "schema_version": 0,
+          "values": {
+            "id": "07ec30c9d869e0f6392f",
+            "value": ""
+          },
+          "sensitive_values": {}
+        },
+        {
+          "address": "random_id.test2",
+          "mode": "managed",
+          "type": "random_id",
+          "name": "test2",
+          "provider_name": "registry.terraform.io/hashicorp/random",
+          "schema_version": 0,
+          "values": {
+            "byte_length": 10,
+            "keepers": null,
+            "prefix": null
+          },
+          "sensitive_values": {}
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "env_variable.test",
+      "mode": "managed",
+      "type": "env_variable",
+      "name": "test",
+      "provider_name": "registry.terraform.io/tchupp/env",
+      "change": {
+        "actions": [
+          "update"
+        ],
+        "before": {
+          "id": "07ec30c9d869e0f6392f",
+          "name": "07ec30c9d869e0f6392f",
+          "value": ""
+        },
+        "after": {
+          "id": "07ec30c9d869e0f6392f",
+          "value": ""
+        },
+        "after_unknown": {
+          "name": true
+        },
+        "before_sensitive": {
+          "value": true
+        },
+        "after_sensitive": {
+          "value": true
+        }
+      }
+    },
+    {
+      "address": "random_id.test",
+      "mode": "managed",
+      "type": "random_id",
+      "name": "test",
+      "provider_name": "registry.terraform.io/hashicorp/random",
+      "change": {
+        "actions": [
+          "delete"
+        ],
+        "before": {
+          "b64_std": "B+wwydhp4PY5Lw==",
+          "b64_url": "B-wwydhp4PY5Lw",
+          "byte_length": 10,
+          "dec": "37413512560416367458607",
+          "hex": "07ec30c9d869e0f6392f",
+          "id": "B-wwydhp4PY5Lw",
+          "keepers": null,
+          "prefix": null
+        },
+        "after": null,
+        "after_unknown": {},
+        "before_sensitive": {},
+        "after_sensitive": false
+      },
+      "action_reason": "delete_because_no_resource_config"
+    },
+    {
+      "address": "random_id.test2",
+      "mode": "managed",
+      "type": "random_id",
+      "name": "test2",
+      "provider_name": "registry.terraform.io/hashicorp/random",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "byte_length": 10,
+          "keepers": null,
+          "prefix": null
+        },
+        "after_unknown": {
+          "b64_std": true,
+          "b64_url": true,
+          "dec": true,
+          "hex": true,
+          "id": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    }
+  ],
+  "prior_state": {
+    "format_version": "1.0",
+    "terraform_version": "1.5.3",
+    "values": {
+      "root_module": {
+        "resources": [
+          {
+            "address": "env_variable.test",
+            "mode": "managed",
+            "type": "env_variable",
+            "name": "test",
+            "provider_name": "registry.terraform.io/tchupp/env",
+            "schema_version": 0,
+            "values": {
+              "id": "07ec30c9d869e0f6392f",
+              "name": "07ec30c9d869e0f6392f",
+              "value": ""
+            },
+            "sensitive_values": {
+              "value": true
+            },
+            "depends_on": [
+              "random_id.test",
+              "random_id.test2"
+            ]
+          },
+          {
+            "address": "random_id.test",
+            "mode": "managed",
+            "type": "random_id",
+            "name": "test",
+            "provider_name": "registry.terraform.io/hashicorp/random",
+            "schema_version": 0,
+            "values": {
+              "b64_std": "B+wwydhp4PY5Lw==",
+              "b64_url": "B-wwydhp4PY5Lw",
+              "byte_length": 10,
+              "dec": "37413512560416367458607",
+              "hex": "07ec30c9d869e0f6392f",
+              "id": "B-wwydhp4PY5Lw",
+              "keepers": null,
+              "prefix": null
+            },
+            "sensitive_values": {}
+          }
+        ]
+      }
+    }
+  },
+  "configuration": {
+    "provider_config": {
+      "env": {
+        "name": "env",
+        "full_name": "registry.terraform.io/tchupp/env",
+        "version_constraint": "0.0.2"
+      },
+      "random": {
+        "name": "random",
+        "full_name": "registry.terraform.io/hashicorp/random"
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "env_variable.test",
+          "mode": "managed",
+          "type": "env_variable",
+          "name": "test",
+          "provider_config_key": "env",
+          "expressions": {
+            "name": {
+              "references": [
+                "random_id.test2.hex",
+                "random_id.test2"
+              ]
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "random_id.test2",
+          "mode": "managed",
+          "type": "random_id",
+          "name": "test2",
+          "provider_config_key": "random",
+          "expressions": {
+            "byte_length": {
+              "constant_value": 10
+            }
+          },
+          "schema_version": 0
+        }
+      ]
+    }
+  },
+  "relevant_attributes": [
+    {
+      "resource": "random_id.test2",
+      "attribute": [
+        "hex"
+      ]
+    }
+  ],
+  "timestamp": "2023-07-24T08:54:19Z"
+}

--- a/test/testdata/known_after_apply/terraform.tfstate
+++ b/test/testdata/known_after_apply/terraform.tfstate
@@ -1,0 +1,53 @@
+{
+  "version": 4,
+  "terraform_version": "1.5.3",
+  "serial": 3,
+  "lineage": "1d34bf50-d823-2b83-b278-e073b69b0213",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "env_variable",
+      "name": "test",
+      "provider": "provider[\"registry.terraform.io/tchupp/env\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "07ec30c9d869e0f6392f",
+            "name": "07ec30c9d869e0f6392f",
+            "value": ""
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "random_id.test"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "random_id",
+      "name": "test",
+      "provider": "provider[\"registry.terraform.io/hashicorp/random\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "b64_std": "B+wwydhp4PY5Lw==",
+            "b64_url": "B-wwydhp4PY5Lw",
+            "byte_length": 10,
+            "dec": "37413512560416367458607",
+            "hex": "07ec30c9d869e0f6392f",
+            "id": "B-wwydhp4PY5Lw",
+            "keepers": null,
+            "prefix": null
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}


### PR DESCRIPTION
fix: https://github.com/reproio/terraform-j2md/issues/10

The plan result often has in-place update with `known after apply` .

```
  # env_variable.test will be updated in-place
  ~ resource "env_variable" "test" {
        id   = "07ec30c9d869e0f6392f"
      ~ name = "07ec30c9d869e0f6392f" -> (known after apply)
    }
```

But terraform-j2md can't interpret `known after apply` now, so the detail looks like deleting the field.

````````diff
# env_variable.test will be updated in-place
@@ -1,6 +1,5 @@
 {
   "id": "07ec30c9d869e0f6392f",
-  "name": "07ec30c9d869e0f6392f",
   "value": "REDACTED_SENSITIVE"
 }
 
````````

This PR changes to display `known after apply` as after changes.

````````diff
# env_variable.test will be updated in-place
@@ -1,6 +1,6 @@
 {
   "id": "07ec30c9d869e0f6392f",
-  "name": "07ec30c9d869e0f6392f",
+  "name": "(known after apply)",
   "value": "REDACTED_SENSITIVE"
 }
 
````````






