### PR TITLE
show instance key of resources

### DIFF
--- a/internal/terraform/unified_diff_renderer.go
+++ b/internal/terraform/unified_diff_renderer.go
@@ -43,13 +43,9 @@ func (r *UnifiedDiffRenderer) Render() (string, error) {
 }
 
 func (r *UnifiedDiffRenderer) Header() string {
-	header := fmt.Sprintf("%s.%s %s", r.ResourceChange.Type, r.ResourceChange.Name, r.headerSuffix())
+	header := fmt.Sprintf("%s %s", r.ResourceChange.Address, r.headerSuffix())
 
-	if r.ResourceChange.ModuleAddress == "" {
-		return header
-	} else {
-		return fmt.Sprintf("%s.%s", r.ResourceChange.ModuleAddress, header)
-	}
+	return header
 }
 
 func (r *UnifiedDiffRenderer) headerSuffix() string {

--- a/test/plan_test/plan_test.go
+++ b/test/plan_test/plan_test.go
@@ -65,6 +65,7 @@ func Test_render(t *testing.T) {
 			{name: "include_module", wantErr: false},
 			{name: "known_after_apply", wantErr: false},
 			{name: "moved_block", wantErr: false},
+			{name: "resource_with_index", wantErr: false},
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {

--- a/test/testdata/resource_with_index/expected.md
+++ b/test/testdata/resource_with_index/expected.md
@@ -1,0 +1,47 @@
+### 2 to add, 0 to change, 0 to destroy, 0 to replace.
+- add
+    - aws_instance.web["t3.micro"]
+    - aws_instance.web["t3.small"]
+<details><summary>Change details</summary>
+
+````````diff
+# aws_instance.web["t3.micro"] will be created
+@@ -1,2 +1,14 @@
+-null
++{
++  "ami": "ami-04fc53a873660e525",
++  "credit_specification": [],
++  "get_password_data": false,
++  "hibernation": null,
++  "instance_type": "t3.micro",
++  "launch_template": [],
++  "source_dest_check": true,
++  "tags": null,
++  "timeouts": null,
++  "user_data_replace_on_change": false,
++  "volume_tags": null
++}
+ 
+````````
+
+````````diff
+# aws_instance.web["t3.small"] will be created
+@@ -1,2 +1,14 @@
+-null
++{
++  "ami": "ami-04fc53a873660e525",
++  "credit_specification": [],
++  "get_password_data": false,
++  "hibernation": null,
++  "instance_type": "t3.small",
++  "launch_template": [],
++  "source_dest_check": true,
++  "tags": null,
++  "timeouts": null,
++  "user_data_replace_on_change": false,
++  "volume_tags": null
++}
+ 
+````````
+
+</details>

--- a/test/testdata/resource_with_index/show.json
+++ b/test/testdata/resource_with_index/show.json
@@ -1,0 +1,319 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.8.5",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_instance.web[\"t3.micro\"]",
+          "mode": "managed",
+          "type": "aws_instance",
+          "name": "web",
+          "index": "t3.micro",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 1,
+          "values": {
+            "ami": "ami-04fc53a873660e525",
+            "credit_specification": [],
+            "get_password_data": false,
+            "hibernation": null,
+            "instance_type": "t3.micro",
+            "launch_template": [],
+            "source_dest_check": true,
+            "tags": null,
+            "timeouts": null,
+            "user_data_replace_on_change": false,
+            "volume_tags": null
+          },
+          "sensitive_values": {
+            "capacity_reservation_specification": [],
+            "credit_specification": [],
+            "ebs_block_device": [],
+            "enclave_options": [],
+            "ephemeral_block_device": [],
+            "ipv6_addresses": [],
+            "launch_template": [],
+            "maintenance_options": [],
+            "metadata_options": [],
+            "network_interface": [],
+            "private_dns_name_options": [],
+            "root_block_device": [],
+            "secondary_private_ips": [],
+            "security_groups": [],
+            "tags_all": {},
+            "vpc_security_group_ids": []
+          }
+        },
+        {
+          "address": "aws_instance.web[\"t3.small\"]",
+          "mode": "managed",
+          "type": "aws_instance",
+          "name": "web",
+          "index": "t3.small",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 1,
+          "values": {
+            "ami": "ami-04fc53a873660e525",
+            "credit_specification": [],
+            "get_password_data": false,
+            "hibernation": null,
+            "instance_type": "t3.small",
+            "launch_template": [],
+            "source_dest_check": true,
+            "tags": null,
+            "timeouts": null,
+            "user_data_replace_on_change": false,
+            "volume_tags": null
+          },
+          "sensitive_values": {
+            "capacity_reservation_specification": [],
+            "credit_specification": [],
+            "ebs_block_device": [],
+            "enclave_options": [],
+            "ephemeral_block_device": [],
+            "ipv6_addresses": [],
+            "launch_template": [],
+            "maintenance_options": [],
+            "metadata_options": [],
+            "network_interface": [],
+            "private_dns_name_options": [],
+            "root_block_device": [],
+            "secondary_private_ips": [],
+            "security_groups": [],
+            "tags_all": {},
+            "vpc_security_group_ids": []
+          }
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "aws_instance.web[\"t3.micro\"]",
+      "mode": "managed",
+      "type": "aws_instance",
+      "name": "web",
+      "index": "t3.micro",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "ami": "ami-04fc53a873660e525",
+          "credit_specification": [],
+          "get_password_data": false,
+          "hibernation": null,
+          "instance_type": "t3.micro",
+          "launch_template": [],
+          "source_dest_check": true,
+          "tags": null,
+          "timeouts": null,
+          "user_data_replace_on_change": false,
+          "volume_tags": null
+        },
+        "after_unknown": {
+          "arn": true,
+          "associate_public_ip_address": true,
+          "availability_zone": true,
+          "capacity_reservation_specification": true,
+          "cpu_core_count": true,
+          "cpu_threads_per_core": true,
+          "credit_specification": [],
+          "disable_api_stop": true,
+          "disable_api_termination": true,
+          "ebs_block_device": true,
+          "ebs_optimized": true,
+          "enclave_options": true,
+          "ephemeral_block_device": true,
+          "host_id": true,
+          "host_resource_group_arn": true,
+          "iam_instance_profile": true,
+          "id": true,
+          "instance_initiated_shutdown_behavior": true,
+          "instance_state": true,
+          "ipv6_address_count": true,
+          "ipv6_addresses": true,
+          "key_name": true,
+          "launch_template": [],
+          "maintenance_options": true,
+          "metadata_options": true,
+          "monitoring": true,
+          "network_interface": true,
+          "outpost_arn": true,
+          "password_data": true,
+          "placement_group": true,
+          "placement_partition_number": true,
+          "primary_network_interface_id": true,
+          "private_dns": true,
+          "private_dns_name_options": true,
+          "private_ip": true,
+          "public_dns": true,
+          "public_ip": true,
+          "root_block_device": true,
+          "secondary_private_ips": true,
+          "security_groups": true,
+          "subnet_id": true,
+          "tags_all": true,
+          "tenancy": true,
+          "user_data": true,
+          "user_data_base64": true,
+          "vpc_security_group_ids": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "capacity_reservation_specification": [],
+          "credit_specification": [],
+          "ebs_block_device": [],
+          "enclave_options": [],
+          "ephemeral_block_device": [],
+          "ipv6_addresses": [],
+          "launch_template": [],
+          "maintenance_options": [],
+          "metadata_options": [],
+          "network_interface": [],
+          "private_dns_name_options": [],
+          "root_block_device": [],
+          "secondary_private_ips": [],
+          "security_groups": [],
+          "tags_all": {},
+          "vpc_security_group_ids": []
+        }
+      }
+    },
+    {
+      "address": "aws_instance.web[\"t3.small\"]",
+      "mode": "managed",
+      "type": "aws_instance",
+      "name": "web",
+      "index": "t3.small",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "ami": "ami-04fc53a873660e525",
+          "credit_specification": [],
+          "get_password_data": false,
+          "hibernation": null,
+          "instance_type": "t3.small",
+          "launch_template": [],
+          "source_dest_check": true,
+          "tags": null,
+          "timeouts": null,
+          "user_data_replace_on_change": false,
+          "volume_tags": null
+        },
+        "after_unknown": {
+          "arn": true,
+          "associate_public_ip_address": true,
+          "availability_zone": true,
+          "capacity_reservation_specification": true,
+          "cpu_core_count": true,
+          "cpu_threads_per_core": true,
+          "credit_specification": [],
+          "disable_api_stop": true,
+          "disable_api_termination": true,
+          "ebs_block_device": true,
+          "ebs_optimized": true,
+          "enclave_options": true,
+          "ephemeral_block_device": true,
+          "host_id": true,
+          "host_resource_group_arn": true,
+          "iam_instance_profile": true,
+          "id": true,
+          "instance_initiated_shutdown_behavior": true,
+          "instance_state": true,
+          "ipv6_address_count": true,
+          "ipv6_addresses": true,
+          "key_name": true,
+          "launch_template": [],
+          "maintenance_options": true,
+          "metadata_options": true,
+          "monitoring": true,
+          "network_interface": true,
+          "outpost_arn": true,
+          "password_data": true,
+          "placement_group": true,
+          "placement_partition_number": true,
+          "primary_network_interface_id": true,
+          "private_dns": true,
+          "private_dns_name_options": true,
+          "private_ip": true,
+          "public_dns": true,
+          "public_ip": true,
+          "root_block_device": true,
+          "secondary_private_ips": true,
+          "security_groups": true,
+          "subnet_id": true,
+          "tags_all": true,
+          "tenancy": true,
+          "user_data": true,
+          "user_data_base64": true,
+          "vpc_security_group_ids": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "capacity_reservation_specification": [],
+          "credit_specification": [],
+          "ebs_block_device": [],
+          "enclave_options": [],
+          "ephemeral_block_device": [],
+          "ipv6_addresses": [],
+          "launch_template": [],
+          "maintenance_options": [],
+          "metadata_options": [],
+          "network_interface": [],
+          "private_dns_name_options": [],
+          "root_block_device": [],
+          "secondary_private_ips": [],
+          "security_groups": [],
+          "tags_all": {},
+          "vpc_security_group_ids": []
+        }
+      }
+    }
+  ],
+  "configuration": {
+    "provider_config": {
+      "aws": {
+        "name": "aws",
+        "full_name": "registry.terraform.io/hashicorp/aws",
+        "expressions": {
+          "region": {
+            "constant_value": "ap-northeast-1"
+          }
+        }
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_instance.web",
+          "mode": "managed",
+          "type": "aws_instance",
+          "name": "web",
+          "provider_config_key": "aws",
+          "expressions": {
+            "ami": {
+              "constant_value": "ami-04fc53a873660e525"
+            },
+            "instance_type": {
+              "references": [
+                "each.value"
+              ]
+            }
+          },
+          "schema_version": 1
+        }
+      ]
+    }
+  },
+  "timestamp": "2024-06-20T12:10:40Z",
+  "applyable": true,
+  "complete": true,
+  "errored": false
+}


### PR DESCRIPTION
In this commit, terraform-j2md uses the `Address` of `ResourceChange` so that it prints the instance keys of resources in the `Change details` section.

ref. https://github.com/hashicorp/terraform-json/blob/a17c11b5a5c100918dc1d277f1bc1b65ade197c2/plan.go#L145

```hcl
provider "aws" {
  region = "ap-northeast-1"
}

resource "aws_instance" "web" {
  for_each      = toset(["t3.micro", "t3.small"])
  ami           = "ami-04fc53a873660e525"
  instance_type = each.value
}
```

## before

### 2 to add, 0 to change, 0 to destroy, 0 to replace.
- add
    - aws_instance.web["t3.micro"]
    - aws_instance.web["t3.small"]
<details><summary>Change details</summary>

````````diff
# aws_instance.web will be created
@@ -1,2 +1,14 @@
-null
+{
+  "ami": "ami-04fc53a873660e525",
+  "credit_specification": [],
+  "get_password_data": false,
+  "hibernation": null,
+  "instance_type": "t3.micro",
+  "launch_template": [],
+  "source_dest_check": true,
+  "tags": null,
+  "timeouts": null,
+  "user_data_replace_on_change": false,
+  "volume_tags": null
+}
 
````````

````````diff
# aws_instance.web will be created
@@ -1,2 +1,14 @@
-null
+{
+  "ami": "ami-04fc53a873660e525",
+  "credit_specification": [],
+  "get_password_data": false,
+  "hibernation": null,
+  "instance_type": "t3.small",
+  "launch_template": [],
+  "source_dest_check": true,
+  "tags": null,
+  "timeouts": null,
+  "user_data_replace_on_change": false,
+  "volume_tags": null
+}
 
````````

</details>


## after

### 2 to add, 0 to change, 0 to destroy, 0 to replace.
- add
    - aws_instance.web["t3.micro"]
    - aws_instance.web["t3.small"]
<details><summary>Change details</summary>

````````diff
# aws_instance.web["t3.micro"] will be created
@@ -1,2 +1,14 @@
-null
+{
+  "ami": "ami-04fc53a873660e525",
+  "credit_specification": [],
+  "get_password_data": false,
+  "hibernation": null,
+  "instance_type": "t3.micro",
+  "launch_template": [],
+  "source_dest_check": true,
+  "tags": null,
+  "timeouts": null,
+  "user_data_replace_on_change": false,
+  "volume_tags": null
+}
 
````````

````````diff
# aws_instance.web["t3.small"] will be created
@@ -1,2 +1,14 @@
-null
+{
+  "ami": "ami-04fc53a873660e525",
+  "credit_specification": [],
+  "get_password_data": false,
+  "hibernation": null,
+  "instance_type": "t3.small",
+  "launch_template": [],
+  "source_dest_check": true,
+  "tags": null,
+  "timeouts": null,
+  "user_data_replace_on_change": false,
+  "volume_tags": null
+}
 
````````

</details>
