### PR TITLE
Add Terraform drift detection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ _terraform-j2md_ reads only standard input, write only standard output.
 terraform-j2md < [input file] > [output file]
 ```
 
+### Options
+- `--no-escape-html`: prevent `<`, `>`, and `&` from being escaped in JSON strings.
+- `--no-drift`: omit the drift detection section from the output. Drift (resources changed outside Terraform) is shown by default whenever the plan reports it.
+
 ## Example
 ````sh
 $ terraform init

--- a/cmd/terraform-j2md/main.go
+++ b/cmd/terraform-j2md/main.go
@@ -10,19 +10,24 @@ import (
 
 var (
 	escapeHTML = true
+	showDrift  = true
 )
 
 func main() {
 	noEscapeHTML := flag.Bool("no-escape-html", false, "prevent <, >, and & from being escaped in JSON strings")
+	noDrift := flag.Bool("no-drift", false, "omit the drift detection section from the output")
 	flag.Parse()
 	if *noEscapeHTML {
 		escapeHTML = false
+	}
+	if *noDrift {
+		showDrift = false
 	}
 	os.Exit(run())
 }
 
 func run() int {
-	planData, err := terraform.NewPlanData(os.Stdin, escapeHTML)
+	planData, err := terraform.NewPlanData(os.Stdin, escapeHTML, showDrift)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "cannot parse input as Terraform plan JSON: %v", err)
 		return 1

--- a/internal/terraform/drift_renderer.go
+++ b/internal/terraform/drift_renderer.go
@@ -1,0 +1,30 @@
+package terraform
+
+import (
+	"fmt"
+
+	tfjson "github.com/hashicorp/terraform-json"
+)
+
+// driftDiffContext is the number of unchanged surrounding lines shown for drift
+// diffs. Drift output lives inside a collapsed <details> block, so we show the
+// full resource state (large value) rather than the tight window used for
+// planned changes.
+const driftDiffContext = 1000
+
+type DriftRenderer struct {
+	ResourceChange   *tfjson.ResourceChange
+	EnableEscapeHTML bool
+}
+
+func NewDriftRenderer(resourceChange *tfjson.ResourceChange, enableEscapeHTML bool) *DriftRenderer {
+	return &DriftRenderer{ResourceChange: resourceChange, EnableEscapeHTML: enableEscapeHTML}
+}
+
+func (r *DriftRenderer) Render() (string, error) {
+	return renderUnifiedDiff(r.ResourceChange, r.EnableEscapeHTML, driftDiffContext, true)
+}
+
+func (r *DriftRenderer) Header() string {
+	return fmt.Sprintf("%s has drifted from state", r.ResourceChange.Address)
+}

--- a/internal/terraform/plan.go
+++ b/internal/terraform/plan.go
@@ -32,7 +32,22 @@ const planTemplateBody = `### {{len .CreatedAddresses}} to add, {{len .UpdatedAd
 - moved{{ range .MovedAddresses }}
     - {{. -}}
 {{end}}{{end}}
-{{if .ResourceChanges -}}
+{{- if .DriftedAddresses}}
+
+### ⚠️ Drift Detected ({{len .DriftedAddresses}} {{if eq (len .DriftedAddresses) 1}}resource{{else}}resources{{end}})
+{{- range .DriftedAddresses}}
+- {{. -}}
+{{end}}{{end}}
+{{- if .ResourceDrift}}
+<details><summary>Drift details</summary>
+{{ range .ResourceDrift }}
+{{codeFence}}diff
+# {{.Header}}
+{{.Render}}{{codeFence}}
+{{end}}
+</details>
+{{end}}
+{{- if .ResourceChanges}}
 <details><summary>Change details</summary>
 {{ range .ResourceChanges }}
 {{codeFence}}diff
@@ -40,6 +55,8 @@ const planTemplateBody = `### {{len .CreatedAddresses}} to add, {{len .UpdatedAd
 {{.Render}}{{codeFence}}
 {{end}}
 </details>
+{{end}}
+{{- if not (or .ResourceDrift .ResourceChanges)}}
 {{end}}`
 
 type PlanData struct {
@@ -48,7 +65,9 @@ type PlanData struct {
 	DeletedAddresses  []string
 	ReplacedAddresses []string
 	MovedAddresses    []string
+	DriftedAddresses  []string
 	ResourceChanges   []ResourceChangeData
+	ResourceDrift     []ResourceChangeData
 }
 
 type ResourceChangeDataRenderer interface {
@@ -106,6 +125,23 @@ func processPlan(plan *tfjson.Plan) (*tfjson.Plan, error) {
 		}
 	}
 
+	for i := range plan.ResourceDrift {
+		plan.ResourceDrift[i].Change, err = sanitize.SanitizeChange(plan.ResourceDrift[i].Change, sanitize.DefaultSensitiveValue)
+		if err != nil {
+			return nil, fmt.Errorf("failed to sanitize drift: %w", err)
+		}
+
+		plan.ResourceDrift[i].Change, err = format.FormatJsonChange(plan.ResourceDrift[i].Change)
+		if err != nil {
+			return nil, fmt.Errorf("failed to format json drift: %w", err)
+		}
+
+		plan.ResourceDrift[i].Change, err = format.FormatUnknownChange(plan.ResourceDrift[i].Change)
+		if err != nil {
+			return nil, fmt.Errorf("failed to format unknown drift: %w", err)
+		}
+	}
+
 	return plan, nil
 }
 
@@ -151,6 +187,21 @@ func NewPlanData(input io.Reader, escapeHTML bool) (*PlanData, error) {
 			Renderer:       NewUnifiedDiffRenderer(c, escapeHTML),
 		})
 	}
+
+	// Process resource drift
+	for _, d := range processedPlan.ResourceDrift {
+		// Skip no-op drift (shouldn't happen, but be safe)
+		if d.Change.Actions.NoOp() {
+			continue
+		}
+
+		planData.DriftedAddresses = append(planData.DriftedAddresses, d.Address)
+		planData.ResourceDrift = append(planData.ResourceDrift, ResourceChangeData{
+			ResourceChange: d,
+			Renderer:       NewDriftRenderer(d, escapeHTML),
+		})
+	}
+
 	return &planData, nil
 }
 

--- a/internal/terraform/plan.go
+++ b/internal/terraform/plan.go
@@ -145,7 +145,7 @@ func processPlan(plan *tfjson.Plan) (*tfjson.Plan, error) {
 	return plan, nil
 }
 
-func NewPlanData(input io.Reader, escapeHTML bool) (*PlanData, error) {
+func NewPlanData(input io.Reader, escapeHTML bool, showDrift bool) (*PlanData, error) {
 	var err error
 	var plan tfjson.Plan
 	if err := json.NewDecoder(input).Decode(&plan); err != nil {
@@ -188,18 +188,20 @@ func NewPlanData(input io.Reader, escapeHTML bool) (*PlanData, error) {
 		})
 	}
 
-	// Process resource drift
-	for _, d := range processedPlan.ResourceDrift {
-		// Skip no-op drift (shouldn't happen, but be safe)
-		if d.Change.Actions.NoOp() {
-			continue
-		}
+	// Process resource drift (skipped when disabled via --no-drift)
+	if showDrift {
+		for _, d := range processedPlan.ResourceDrift {
+			// Skip no-op drift (shouldn't happen, but be safe)
+			if d.Change.Actions.NoOp() {
+				continue
+			}
 
-		planData.DriftedAddresses = append(planData.DriftedAddresses, d.Address)
-		planData.ResourceDrift = append(planData.ResourceDrift, ResourceChangeData{
-			ResourceChange: d,
-			Renderer:       NewDriftRenderer(d, escapeHTML),
-		})
+			planData.DriftedAddresses = append(planData.DriftedAddresses, d.Address)
+			planData.ResourceDrift = append(planData.ResourceDrift, ResourceChangeData{
+				ResourceChange: d,
+				Renderer:       NewDriftRenderer(d, escapeHTML),
+			})
+		}
 	}
 
 	return &planData, nil

--- a/internal/terraform/unified_diff_renderer.go
+++ b/internal/terraform/unified_diff_renderer.go
@@ -19,20 +19,33 @@ func NewUnifiedDiffRenderer(resourceChange *tfjson.ResourceChange, enableEscapeH
 }
 
 func (r *UnifiedDiffRenderer) Render() (string, error) {
-	before, err := r.marshalChangeBefore()
+	return renderUnifiedDiff(r.ResourceChange, r.EnableEscapeHTML, 3, false)
+}
+
+// renderUnifiedDiff renders a resource change's before/after as a unified diff.
+// context is the number of unchanged surrounding lines to show. Shared by the
+// resource-change and drift renderers.
+//
+// trimTrailingNewline drops the newline json.Encode appends. Drift needs this:
+// at high Context, SplitLines on a newline-terminated string yields a trailing
+// empty element that surfaces as a spurious diff line. The change renderer must
+// NOT trim — it would alter existing (upstream) change output for resources
+// whose change lands within Context lines of the end.
+func renderUnifiedDiff(rc *tfjson.ResourceChange, escapeHTML bool, context int, trimTrailingNewline bool) (string, error) {
+	before, err := marshalDiffValue(rc.Change.Before, escapeHTML, trimTrailingNewline)
 	if err != nil {
-		return "", fmt.Errorf("invalid resource changes (before): %w", err)
+		return "", fmt.Errorf("invalid resource change (before): %w", err)
 	}
-	after, err := r.marshalChangeAfter()
+	after, err := marshalDiffValue(rc.Change.After, escapeHTML, trimTrailingNewline)
 	if err != nil {
-		return "", fmt.Errorf("invalid resource changes (after) : %w", err)
+		return "", fmt.Errorf("invalid resource change (after): %w", err)
 	}
 	// Try to parse JSON string in values
 	replacer := strings.NewReplacer(`\n`, "\n  ", `\"`, "\"")
 	diff := difflib.UnifiedDiff{
 		A:       difflib.SplitLines(replacer.Replace(string(before))),
 		B:       difflib.SplitLines(replacer.Replace(string(after))),
-		Context: 3,
+		Context: context,
 	}
 	diffText, err := difflib.GetUnifiedDiffString(diff)
 	if err != nil {
@@ -40,6 +53,20 @@ func (r *UnifiedDiffRenderer) Render() (string, error) {
 	}
 
 	return diffText, nil
+}
+
+func marshalDiffValue(v any, escapeHTML, trimTrailingNewline bool) ([]byte, error) {
+	var buffer bytes.Buffer
+	enc := json.NewEncoder(&buffer)
+	enc.SetIndent("", "  ")
+	enc.SetEscapeHTML(escapeHTML)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	if trimTrailingNewline {
+		return bytes.TrimRight(buffer.Bytes(), "\n"), nil
+	}
+	return buffer.Bytes(), nil
 }
 
 func (r *UnifiedDiffRenderer) Header() string {
@@ -60,24 +87,4 @@ func (r *UnifiedDiffRenderer) headerSuffix() string {
 		return "will be replaced"
 	}
 	return ""
-}
-
-func (r *UnifiedDiffRenderer) marshalChangeBefore() ([]byte, error) {
-	return r.marshalChange(r.ResourceChange.Change.Before)
-}
-
-func (r *UnifiedDiffRenderer) marshalChangeAfter() ([]byte, error) {
-	return r.marshalChange(r.ResourceChange.Change.After)
-}
-
-func (r *UnifiedDiffRenderer) marshalChange(v any) ([]byte, error) {
-	var buffer bytes.Buffer
-	enc := json.NewEncoder(&buffer)
-	enc.SetIndent("", "  ")
-	enc.SetEscapeHTML(r.EnableEscapeHTML)
-	err := enc.Encode(v)
-	if err != nil {
-		return nil, err
-	}
-	return buffer.Bytes(), nil
 }

--- a/test/plan_test/plan_test.go
+++ b/test/plan_test/plan_test.go
@@ -25,6 +25,7 @@ func Test_newPlanData(t *testing.T) {
 		{name: "all_types_mixed", wantErr: false},
 		{name: "aws_sample", wantErr: false},
 		{name: "iam_policy", wantErr: false},
+		{name: "drift_only", wantErr: false},
 		{name: "invalid_json", wantErr: true},
 		{name: "not_json", wantErr: true},
 	}
@@ -61,6 +62,7 @@ func Test_render(t *testing.T) {
 			{name: "all_types_mixed", wantErr: false},
 			{name: "aws_sample", wantErr: false},
 			{name: "iam_policy", wantErr: false},
+			{name: "drift_only", wantErr: false},
 			{name: "include_code_fence", wantErr: false},
 			{name: "include_module", wantErr: false},
 			{name: "known_after_apply", wantErr: false},

--- a/test/plan_test/plan_test.go
+++ b/test/plan_test/plan_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/reproio/terraform-j2md/internal/terraform"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -39,12 +40,37 @@ func Test_newPlanData(t *testing.T) {
 			}
 			defer file.Close()
 
-			_, err = terraform.NewPlanData(file, false)
+			_, err = terraform.NewPlanData(file, false, true)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewPlanData() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 		})
+	}
+}
+
+func Test_render_noDrift(t *testing.T) {
+	// drift_only has drift but no planned changes; with drift disabled the
+	// output must contain no drift section.
+	inputFilePath := testDataPath("drift_only", "show.json")
+	file, err := os.Open(inputFilePath)
+	if err != nil {
+		t.Fatalf("cannot open input file: %s", inputFilePath)
+	}
+	defer file.Close()
+
+	plan, err := terraform.NewPlanData(file, true, false)
+	if err != nil {
+		t.Fatalf("cannot parse JSON as plan: %v", err)
+	}
+
+	got := bytes.Buffer{}
+	if err := plan.Render(&got); err != nil {
+		t.Fatalf("render() error = %v", err)
+	}
+
+	if strings.Contains(got.String(), "Drift Detected") {
+		t.Errorf("render() with drift disabled still contains drift section:\n%s", got.String())
 	}
 }
 
@@ -79,7 +105,7 @@ func Test_render(t *testing.T) {
 				}
 				defer file.Close()
 
-				plan, err := terraform.NewPlanData(file, true)
+				plan, err := terraform.NewPlanData(file, true, true)
 				if err != nil {
 					t.Errorf("cannot parse JSON as plan: %v", err)
 					return
@@ -123,7 +149,7 @@ func Test_render(t *testing.T) {
 				}
 				defer file.Close()
 
-				plan, err := terraform.NewPlanData(file, false)
+				plan, err := terraform.NewPlanData(file, false, true)
 				if err != nil {
 					t.Errorf("cannot parse JSON as plan: %v", err)
 					return

--- a/test/testdata/aws_sample/expected.md
+++ b/test/testdata/aws_sample/expected.md
@@ -8,6 +8,128 @@
     - aws_instance.test
 - replace
     - aws_security_group.admin
+
+### ⚠️ Drift Detected (4 resources)
+- aws_internet_gateway.myGW
+- aws_key_pair.my-key-pair
+- aws_security_group.admin
+- aws_vpc.myVPC
+<details><summary>Drift details</summary>
+
+````````diff
+# aws_internet_gateway.myGW has drifted from state
+@@ -1,8 +1,8 @@
+ {
+   "arn": "arn:aws:ec2:ap-northeast-1:999999999999:internet-gateway/igw-0edc99b3ee0ed84ad",
+   "id": "igw-0edc99b3ee0ed84ad",
+   "owner_id": "999999999999",
+-  "tags": null,
++  "tags": {},
+   "tags_all": {},
+   "vpc_id": "vpc-0c08ee65bf93a360f"
+ }
+````````
+
+````````diff
+# aws_key_pair.my-key-pair has drifted from state
+@@ -1,11 +1,11 @@
+ {
+   "arn": "arn:aws:ec2:ap-northeast-1:999999999999:key-pair/id_rsa_ec2",
+   "fingerprint": "f9:95:17:a6:4d:1d:be:60:54:fa:a5:51:df:16:40:56",
+   "id": "id_rsa_ec2",
+   "key_name": "id_rsa_ec2",
+   "key_name_prefix": "",
+   "key_pair_id": "key-0f1fe4f4c50caede6",
+   "public_key": "ssh-rsa XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+-  "tags": null,
++  "tags": {},
+   "tags_all": {}
+ }
+````````
+
+````````diff
+# aws_security_group.admin has drifted from state
+@@ -1,43 +1,43 @@
+ {
+   "arn": "arn:aws:ec2:ap-northeast-1:999999999999:security-group/sg-05bf69021f9e927aa",
+   "description": "test",
+   "egress": [
+     {
+       "cidr_blocks": [
+         "0.0.0.0/0"
+       ],
+       "description": "",
+       "from_port": 0,
+       "ipv6_cidr_blocks": [],
+       "prefix_list_ids": [],
+       "protocol": "-1",
+       "security_groups": [],
+       "self": false,
+       "to_port": 0
+     }
+   ],
+   "id": "sg-05bf69021f9e927aa",
+   "ingress": [
+     {
+       "cidr_blocks": [
+         "0.0.0.0/0"
+       ],
+       "description": "",
+       "from_port": 22,
+       "ipv6_cidr_blocks": [],
+       "prefix_list_ids": [],
+       "protocol": "tcp",
+       "security_groups": [],
+       "self": false,
+       "to_port": 22
+     }
+   ],
+   "name": "admin",
+   "name_prefix": "",
+   "owner_id": "999999999999",
+   "revoke_rules_on_delete": false,
+-  "tags": null,
++  "tags": {},
+   "tags_all": {},
+   "timeouts": null,
+   "vpc_id": "vpc-0c08ee65bf93a360f"
+ }
+````````
+
+````````diff
+# aws_vpc.myVPC has drifted from state
+@@ -1,26 +1,26 @@
+ {
+   "arn": "arn:aws:ec2:ap-northeast-1:999999999999:vpc/vpc-0c08ee65bf93a360f",
+   "assign_generated_ipv6_cidr_block": false,
+   "cidr_block": "10.1.0.0/16",
+   "default_network_acl_id": "acl-044c353daa9d7d946",
+   "default_route_table_id": "rtb-024550946eba617ac",
+   "default_security_group_id": "sg-03e2efb1831bb7701",
+   "dhcp_options_id": "dopt-001eeab035675bf4c",
+   "enable_classiclink": false,
+   "enable_classiclink_dns_support": false,
+   "enable_dns_hostnames": false,
+   "enable_dns_support": true,
+   "id": "vpc-0c08ee65bf93a360f",
+   "instance_tenancy": "default",
+   "ipv4_ipam_pool_id": null,
+   "ipv4_netmask_length": null,
+   "ipv6_association_id": "",
+   "ipv6_cidr_block": "",
+   "ipv6_cidr_block_network_border_group": "",
+   "ipv6_ipam_pool_id": "",
+   "ipv6_netmask_length": 0,
+   "main_route_table_id": "rtb-024550946eba617ac",
+   "owner_id": "999999999999",
+-  "tags": null,
++  "tags": {},
+   "tags_all": {}
+ }
+````````
+
+</details>
+
 <details><summary>Change details</summary>
 
 ````````diff

--- a/test/testdata/drift_only/expected.md
+++ b/test/testdata/drift_only/expected.md
@@ -1,0 +1,51 @@
+### 0 to add, 0 to change, 0 to destroy, 0 to replace.
+
+### ⚠️ Drift Detected (2 resources)
+- aws_instance.web
+- aws_security_group.allow_http
+<details><summary>Drift details</summary>
+
+````````diff
+# aws_instance.web has drifted from state
+@@ -1,9 +1,10 @@
+ {
+   "ami": "ami-12345678",
+   "arn": "arn:aws:ec2:us-east-1:123456789012:instance/i-1234567890abcdef0",
+   "id": "i-1234567890abcdef0",
+   "instance_type": "t2.micro",
+   "tags": {
++    "Environment": "production",
+     "Name": "web-server"
+   }
+ }
+````````
+
+````````diff
+# aws_security_group.allow_http has drifted from state
+@@ -1,15 +1,23 @@
+ {
+   "description": "Allow HTTP traffic",
+   "id": "sg-0123456789abcdef0",
+   "ingress": [
+     {
+       "cidr_blocks": [
+         "0.0.0.0/0"
+       ],
+       "from_port": 80,
+       "protocol": "tcp",
+       "to_port": 80
++    },
++    {
++      "cidr_blocks": [
++        "0.0.0.0/0"
++      ],
++      "from_port": 443,
++      "protocol": "tcp",
++      "to_port": 443
+     }
+   ],
+   "name": "allow_http"
+ }
+````````
+
+</details>

--- a/test/testdata/drift_only/main.tf
+++ b/test/testdata/drift_only/main.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+# EC2 instance - tags were modified outside Terraform
+resource "aws_instance" "web" {
+  ami           = "ami-12345678"
+  instance_type = "t2.micro"
+
+  tags = {
+    Name        = "web-server"
+    Environment = "production"
+  }
+}
+
+# Security group - ingress rule was added outside Terraform
+resource "aws_security_group" "allow_http" {
+  name        = "allow_http"
+  description = "Allow HTTP traffic"
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/test/testdata/drift_only/plan.txt
+++ b/test/testdata/drift_only/plan.txt
@@ -1,0 +1,42 @@
+aws_instance.web: Refreshing state... [id=i-1234567890abcdef0]
+aws_security_group.allow_http: Refreshing state... [id=sg-0123456789abcdef0]
+
+Note: Objects have changed outside of Terraform
+
+Terraform detected the following changes made outside of Terraform since the last "terraform apply":
+
+  # aws_instance.web has changed
+  ~ resource "aws_instance" "web" {
+        id            = "i-1234567890abcdef0"
+      ~ tags          = {
+          + "Environment" = "production"
+            "Name"        = "web-server"
+        }
+        # (5 unchanged attributes hidden)
+    }
+
+  # aws_security_group.allow_http has changed
+  ~ resource "aws_security_group" "allow_http" {
+        id          = "sg-0123456789abcdef0"
+        name        = "allow_http"
+      + ingress {
+          + cidr_blocks      = [
+              + "0.0.0.0/0",
+            ]
+          + from_port        = 443
+          + protocol         = "tcp"
+          + to_port          = 443
+        }
+        # (3 unchanged attributes hidden)
+    }
+
+Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes,
+the following plan may include actions to undo or respond to these changes.
+
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+No changes. Your infrastructure matches the configuration.
+
+Your configuration already matches the changes detected above. If you'd like to update the Terraform state to match,
+create and apply a refresh-only plan:
+  terraform apply -refresh-only

--- a/test/testdata/drift_only/show.json
+++ b/test/testdata/drift_only/show.json
@@ -1,0 +1,205 @@
+{
+  "format_version": "1.0",
+  "terraform_version": "1.5.0",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_instance.web",
+          "mode": "managed",
+          "type": "aws_instance",
+          "name": "web",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 1,
+          "values": {
+            "ami": "ami-12345678",
+            "instance_type": "t2.micro",
+            "tags": {
+              "Name": "web-server",
+              "Environment": "production"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "resource_changes": [],
+  "resource_drift": [
+    {
+      "address": "aws_instance.web",
+      "mode": "managed",
+      "type": "aws_instance",
+      "name": "web",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": [
+          "update"
+        ],
+        "before": {
+          "ami": "ami-12345678",
+          "arn": "arn:aws:ec2:us-east-1:123456789012:instance/i-1234567890abcdef0",
+          "id": "i-1234567890abcdef0",
+          "instance_type": "t2.micro",
+          "tags": {
+            "Name": "web-server"
+          }
+        },
+        "after": {
+          "ami": "ami-12345678",
+          "arn": "arn:aws:ec2:us-east-1:123456789012:instance/i-1234567890abcdef0",
+          "id": "i-1234567890abcdef0",
+          "instance_type": "t2.micro",
+          "tags": {
+            "Name": "web-server",
+            "Environment": "production"
+          }
+        },
+        "after_unknown": {},
+        "before_sensitive": {},
+        "after_sensitive": {}
+      }
+    },
+    {
+      "address": "aws_security_group.allow_http",
+      "mode": "managed",
+      "type": "aws_security_group",
+      "name": "allow_http",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": [
+          "update"
+        ],
+        "before": {
+          "id": "sg-0123456789abcdef0",
+          "name": "allow_http",
+          "description": "Allow HTTP traffic",
+          "ingress": [
+            {
+              "from_port": 80,
+              "to_port": 80,
+              "protocol": "tcp",
+              "cidr_blocks": [
+                "0.0.0.0/0"
+              ]
+            }
+          ]
+        },
+        "after": {
+          "id": "sg-0123456789abcdef0",
+          "name": "allow_http",
+          "description": "Allow HTTP traffic",
+          "ingress": [
+            {
+              "from_port": 80,
+              "to_port": 80,
+              "protocol": "tcp",
+              "cidr_blocks": [
+                "0.0.0.0/0"
+              ]
+            },
+            {
+              "from_port": 443,
+              "to_port": 443,
+              "protocol": "tcp",
+              "cidr_blocks": [
+                "0.0.0.0/0"
+              ]
+            }
+          ]
+        },
+        "after_unknown": {},
+        "before_sensitive": {},
+        "after_sensitive": {}
+      }
+    }
+  ],
+  "prior_state": {
+    "format_version": "1.0",
+    "terraform_version": "1.5.0",
+    "values": {
+      "root_module": {
+        "resources": [
+          {
+            "address": "aws_instance.web",
+            "mode": "managed",
+            "type": "aws_instance",
+            "name": "web",
+            "provider_name": "registry.terraform.io/hashicorp/aws",
+            "schema_version": 1,
+            "values": {
+              "ami": "ami-12345678",
+              "id": "i-1234567890abcdef0",
+              "instance_type": "t2.micro",
+              "tags": {
+                "Name": "web-server"
+              }
+            }
+          },
+          {
+            "address": "aws_security_group.allow_http",
+            "mode": "managed",
+            "type": "aws_security_group",
+            "name": "allow_http",
+            "provider_name": "registry.terraform.io/hashicorp/aws",
+            "schema_version": 1,
+            "values": {
+              "id": "sg-0123456789abcdef0",
+              "name": "allow_http",
+              "description": "Allow HTTP traffic"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "configuration": {
+    "provider_config": {
+      "aws": {
+        "name": "aws",
+        "version_constraint": "~> 5.0"
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_instance.web",
+          "mode": "managed",
+          "type": "aws_instance",
+          "name": "web",
+          "provider_config_key": "aws",
+          "expressions": {
+            "ami": {
+              "constant_value": "ami-12345678"
+            },
+            "instance_type": {
+              "constant_value": "t2.micro"
+            },
+            "tags": {
+              "constant_value": {
+                "Name": "web-server",
+                "Environment": "production"
+              }
+            }
+          },
+          "schema_version": 1
+        },
+        {
+          "address": "aws_security_group.allow_http",
+          "mode": "managed",
+          "type": "aws_security_group",
+          "name": "allow_http",
+          "provider_config_key": "aws",
+          "expressions": {
+            "name": {
+              "constant_value": "allow_http"
+            },
+            "description": {
+              "constant_value": "Allow HTTP traffic"
+            }
+          },
+          "schema_version": 1
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds rendering of **resource drift** to the generated Markdown. Terraform records out-of-band changes (infrastructure modified outside Terraform, detected during refresh) in the `resource_drift` array of `terraform show -json` output. Previously this was silently dropped; now it renders as a distinct section.

## Behaviour

- A new `### ⚠️ Drift Detected (N resources)` heading lists the drifted addresses, followed by a collapsed `<details>` block with a per-resource unified diff of the drifted state — kept separate from the planned create/update/delete/replace summary and its own `Change details` block.
- **On by default**, mirroring `terraform plan`, which surfaces drift without a flag. Pass `--no-drift` to omit the section (same opt-out convention as the existing `--no-escape-html`).
- The section renders **only when the plan reports drift** — output is byte-for-byte unchanged when `resource_drift` is empty.

## Notes

- Drift before/after values go through the same `SanitizeChange` + `FormatJsonChange` + `FormatUnknownChange` pipeline as planned changes, so sensitive values are redacted in drift output too.
- The drift and change renderers share a single `renderUnifiedDiff` helper. Drift uses full context (to show complete resource state inside the collapsed block); planned changes keep the existing 3-line context. **The change renderer's output is unchanged.**
- No new dependencies.

## Tests

- New `drift_only` fixture (drift, no planned changes) and a `Test_render_noDrift` case covering `--no-drift`.
- `aws_sample` fixture extended to cover mixed drift + planned changes.
- `go build`, `go vet`, `go test ./...` all pass.

---

## Example rendered output

Given a plan where an `aws_instance` gained a tag and an `aws_security_group` gained an ingress rule outside Terraform (and no planned changes), `terraform show -json plan.tfplan | terraform-j2md` renders:

### 0 to add, 0 to change, 0 to destroy, 0 to replace.

### ⚠️ Drift Detected (2 resources)
- aws_instance.web
- aws_security_group.allow_http
<details><summary>Drift details</summary>

```diff
# aws_instance.web has drifted from state
@@ -1,9 +1,10 @@
 {
   "ami": "ami-12345678",
   "arn": "arn:aws:ec2:us-east-1:123456789012:instance/i-1234567890abcdef0",
   "id": "i-1234567890abcdef0",
   "instance_type": "t2.micro",
   "tags": {
+    "Environment": "production",
     "Name": "web-server"
   }
 }
```

```diff
# aws_security_group.allow_http has drifted from state
@@ -1,15 +1,23 @@
 {
   "description": "Allow HTTP traffic",
   "id": "sg-0123456789abcdef0",
   "ingress": [
     {
       "cidr_blocks": [
         "0.0.0.0/0"
       ],
       "from_port": 80,
       "protocol": "tcp",
       "to_port": 80
+    },
+    {
+      "cidr_blocks": [
+        "0.0.0.0/0"
+      ],
+      "from_port": 443,
+      "protocol": "tcp",
+      "to_port": 443
     }
   ],
   "name": "allow_http"
 }
```

</details>

_(This example is the `test/testdata/drift_only/expected.md` fixture, shown rendered.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
